### PR TITLE
Upgraded the Microsoft library dependency to 2.1.4 which handles retr…

### DIFF
--- a/db-cp/build.sbt
+++ b/db-cp/build.sbt
@@ -7,7 +7,7 @@ name in ThisBuild := "db-cp"
 
 organization in ThisBuild := "com.starbucks.analytics"
 
-version in ThisBuild := "0.9"
+version in ThisBuild := "1.0"
 
 licenses in ThisBuild += ("Apache License, Version 2.0", url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 

--- a/db-cp/project/Dependencies.scala
+++ b/db-cp/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   lazy val slf4j_api = "org.slf4j" % "slf4j-api" % "1.7.21"
   lazy val logback = "ch.qos.logback" % "logback-classic" % "1.1.7"
   lazy val scopt = "com.github.scopt" %% "scopt" % "3.5.0"
-  lazy val azure_data_lake_store_sdk = "com.microsoft.azure" % "azure-data-lake-store-sdk" % "2.0.4-SNAPSHOT"
+  lazy val azure_data_lake_store_sdk = "com.microsoft.azure" % "azure-data-lake-store-sdk" % "2.1.4"
   lazy val guice = "net.codingwell" %% "scala-guice" % "4.1.0"
 
   // Provided scope:


### PR DESCRIPTION
…y logic when uploading to the ADLS. When there is a retry, the uploader tries to write to the same position which may have been written already during failure. This bug was handled in the newer library released by Microsoft