### PR TITLE
Support for parsing java properties

### DIFF
--- a/db-cp/build.sbt
+++ b/db-cp/build.sbt
@@ -7,7 +7,7 @@ name in ThisBuild := "db-cp"
 
 organization in ThisBuild := "com.starbucks.analytics"
 
-version in ThisBuild := "1.0"
+version in ThisBuild := "1.1"
 
 licenses in ThisBuild += ("Apache License, Version 2.0", url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 

--- a/db-cp/src/main/scala/com/starbucks/analytics/parsercombinator/Token.scala
+++ b/db-cp/src/main/scala/com/starbucks/analytics/parsercombinator/Token.scala
@@ -11,6 +11,7 @@ case class EMPTY() extends Token
 case class LITERAL(str: String) extends Token
 case class IDENTIFIER(str: String) extends Token
 case class VARIABLE(str: String) extends Token
+case class ENVIRONMENT_VARIABLE(str: String) extends Token
 case class INTERPOLATION(str: String) extends Token
 case class SQL(str: String) extends Token
 case class OPERATOR(op: String) extends Token


### PR DESCRIPTION
The tool's parameter is a SQL file. The file contains sensitive information such as client key, user name et al. By having this hardcoded in this file, it makes it difficult rotate keys or change password. To facilitate, I am now taking in java properties that you can pass from command line.